### PR TITLE
feat: support Vite 8 by skipping manualChunks when codeSplitting is c…

### DIFF
--- a/packages/lib/src/prod/shared-production.ts
+++ b/packages/lib/src/prod/shared-production.ts
@@ -163,6 +163,13 @@ export function prodSharedPlugin(
         return find ? find[0] : undefined
       }
 
+      // Vite 8+ uses Rolldown which supports codeSplitting as a replacement
+      // for manualChunks. When codeSplitting is configured, setting
+      // manualChunks causes a warning and is ignored. Skip setting it.
+      if ((outputOption as any).codeSplitting) {
+        return outputOption
+      }
+
       // only active when manualChunks is function,array not to solve
       if (typeof outputOption.manualChunks === 'function') {
         outputOption.manualChunks = new Proxy(outputOption.manualChunks, {


### PR DESCRIPTION
…onfigured

Vite 8 uses Rolldown which introduces codeSplitting as a replacement for manualChunks. When codeSplitting is present on the output options, Rolldown ignores manualChunks and emits a warning. Skip setting manualChunks in this case to avoid the warning.

Bumps version to 1.4.1-hugs.5.

Amp-Thread-ID: https://ampcode.com/threads/T-019d04a0-b440-70e5-9ba0-aa88f4de9df4

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Code of Conduct](https://github.com/hugs7/vite-plugin-federation/blob/main/CODE_OF_CONDUCT.md) and follow the [Commit Convention](https://github.com/hugs7/vite-plugin-federation/blob/main/.github/commit-convention.md) guidelines.
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
