### PR TITLE
fix: generate share scope when shared modules configured without remotes

### DIFF
--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -58,12 +58,16 @@ export function devRemotePlugin(
     .concat(needHandleFileType)
     .map((item) => item.toLowerCase())
   const transformFileTypeSet = new Set(options.transformFileTypes)
+  const hasRemotes = !!options.remotes
+  const hasShared = parsedOptions.devShared.length > 0
+  const needsFederationModule = hasRemotes || hasShared
+
   return {
     name: 'hugs7:remote-development',
-    virtualFile: options.remotes
+    virtualFile: needsFederationModule
       ? {
           __federation__: `
-${createRemotesMap(devRemotes)}
+${hasRemotes ? createRemotesMap(devRemotes) : 'const remotesMap = {};'}
 const loadJS = async (url, fn) => {
   const resolvedUrl = typeof url === 'function' ? await url() : url;
   const script = document.createElement('script')
@@ -199,7 +203,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
       }
     },
     async transform(this: TransformPluginContext, code: string, id: string) {
-      if (builderInfo.isHost && !builderInfo.isRemote) {
+      if ((builderInfo.isHost || builderInfo.isShared) && !builderInfo.isRemote) {
         for (const arr of parsedOptions.devShared) {
           if (!arr[1].version && !arr[1].manuallyPackagePathSetting) {
             const packageJsonPath = (

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -62,7 +62,8 @@ export default function federation(
       pluginList = []
     }
     builderInfo.isHost = !!(
-      parsedOptions.prodRemote.length || parsedOptions.devRemote.length
+      parsedOptions.prodRemote.length || parsedOptions.devRemote.length ||
+      parsedOptions.prodShared.length || parsedOptions.devShared.length
     )
     builderInfo.isRemote = !!(
       parsedOptions.prodExpose.length || parsedOptions.devExpose.length

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -111,13 +111,16 @@ export function prodRemotePlugin(
   const shareScope = options.shareScope || 'default'
   let resolvedConfig: ResolvedConfig
   let federationRuntimeEmitted = false
+  const hasRemotes = !!options.remotes
+  const hasShared = parsedOptions.prodShared.length > 0
+  const needsFederationModule = hasRemotes || hasShared
   return {
     name: 'hugs7:remote-production',
-    virtualFile: options.remotes
+    virtualFile: needsFederationModule
       ? {
           // language=JS
           __federation__: `
-                ${createRemotesMap(prodRemotes)}
+                ${hasRemotes ? createRemotesMap(prodRemotes) : 'const remotesMap = {};'}
                 const currentImports = {}
                 const loadJS = async (url, fn) => {
                     const resolvedUrl = typeof url === 'function' ? await url() : url;
@@ -290,7 +293,7 @@ export function prodRemotePlugin(
       // (e.g. in vendor-framework) would import federation functions from the
       // entry chunk, creating circular static imports that deadlock when
       // combined with TLA from await importShared().
-      if (builderInfo.isHost && options.remotes && !federationRuntimeEmitted) {
+      if (builderInfo.isHost && needsFederationModule && !federationRuntimeEmitted) {
         federationRuntimeEmitted = true
         this.emitFile({
           type: 'chunk',

--- a/packages/lib/src/prod/shared-production.ts
+++ b/packages/lib/src/prod/shared-production.ts
@@ -42,7 +42,7 @@ export function prodSharedPlugin(
     options(inputOptions) {
       isRemote = !!parsedOptions.prodExpose.length
       isHost =
-        !!parsedOptions.prodRemote.length && !parsedOptions.prodExpose.length
+        (!!parsedOptions.prodRemote.length || !!parsedOptions.prodShared.length) && !parsedOptions.prodExpose.length
 
       if (shareName2Prop.size) {
         // remove item which is both in external and shared


### PR DESCRIPTION
The __federation__ virtual module was only generated when remotes existed, causing runtime-added remotes via __federation_method_setRemote to fail because no share scope was initialized. Now the federation runtime and share scope are generated whenever shared modules are configured, using an empty remotesMap when no remotes are present at build time.
