### PR TITLE
fix: use separate temp directories per e2e mode to avoid Windows EBUSY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ package-lock.json
 
 launch.json
 temp
+temp-*

--- a/packages/examples/basic-host-remote/package.json
+++ b/packages/examples/basic-host-remote/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "build": "pnpm --parallel --filter \"./**\" build",
-    "serve": "pnpm --parallel --filter \"./**\" serve",
+    "build": "pnpm --parallel --filter \"./**\" --filter \"!.\" build",
+    "serve": "pnpm --parallel --filter \"./**\" --filter \"!.\" serve",
     "stop": "kill-port --port 5000,5001"
   },
   "license": "MulanPSL-2.0",

--- a/packages/examples/react-in-vue/package.json
+++ b/packages/examples/react-in-vue/package.json
@@ -7,8 +7,8 @@
     "layout"
   ],
   "scripts": {
-    "build": "pnpm  --parallel --filter \"./**\" build",
-    "serve": "pnpm  --parallel --filter \"./**\" serve",
+    "build": "pnpm  --parallel --filter \"./**\" --filter \"!.\" build",
+    "serve": "pnpm  --parallel --filter \"./**\" --filter \"!.\" serve",
     "stop": "kill-port --port 5000,5001"
   },
   "devDependencies": {

--- a/packages/examples/react-vite/package.json
+++ b/packages/examples/react-vite/package.json
@@ -3,8 +3,8 @@
     "private": true,
     "version": "1.0.0",
     "scripts": {
-      "build": "pnpm --parallel --filter \"./**\" build",
-      "serve": "pnpm --parallel --filter \"./**\" preview",
+      "build": "pnpm --parallel --filter \"./**\" --filter \"!.\" build",
+      "serve": "pnpm --parallel --filter \"./**\" --filter \"!.\" preview",
       "build:remotes": "pnpm --parallel --filter \"./remote\" build",
       "serve:remotes": "pnpm --parallel --filter \"./remote\" serve",
       "dev:hosts": "pnpm --filter \"./host\" dev",

--- a/packages/examples/simple-react-esm/package.json
+++ b/packages/examples/simple-react-esm/package.json
@@ -12,8 +12,8 @@
   },
   "license": "MulanPSL-2.0",
   "scripts": {
-    "build": "pnpm --parallel --filter \"./**\" build ",
-    "serve": "pnpm --parallel --filter \"./**\" serve",
+    "build": "pnpm --parallel --filter \"./**\" --filter \"!.\" build ",
+    "serve": "pnpm --parallel --filter \"./**\" --filter \"!.\" serve",
     "stop": "kill-port --port 5000,5001"
   },
   "devDependencies": {

--- a/packages/examples/vitestGlobalSetup.ts
+++ b/packages/examples/vitestGlobalSetup.ts
@@ -58,8 +58,6 @@ export async function setup(): Promise<void> {
 export async function teardown(): Promise<void> {
   await browserServer?.close()
   if (!process.env.VITE_PRESERVE_BUILD_ARTIFACTS) {
-    // Best-effort cleanup. If the temp directory is still locked (Windows),
-    // the next run's setup will clean it before re-copying.
     await kill('5000,5001,5002,5003,5004').catch(() => {})
     if (process.platform === 'win32') {
       await new Promise((r) => setTimeout(r, 2000))

--- a/packages/examples/vue3-advanced-demo/package.json
+++ b/packages/examples/vue3-advanced-demo/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "start": "pnpm start",
-    "build": "pnpm --parallel --filter \"./**\" build ",
-    "serve": "pnpm --parallel --filter \"./**\" serve ",
+    "build": "pnpm --parallel --filter \"./**\" --filter \"!.\" build ",
+    "serve": "pnpm --parallel --filter \"./**\" --filter \"!.\" serve ",
     "restart": "pnpm stop & pnpm build & pnpm serve",
     "build:remotes": "pnpm --parallel --filter \"./team-blue\" --filter \"./team-green\"  build",
     "serve:remotes": "pnpm --parallel --filter \"./team-blue\" --filter \"./team-green\"  serve",

--- a/packages/examples/vue3-demo-esm-expose-store/package.json
+++ b/packages/examples/vue3-demo-esm-expose-store/package.json
@@ -7,8 +7,8 @@
     "remote"
   ],
   "scripts": {
-    "build": "pnpm --parallel --filter \"./**\" build ",
-    "serve": "pnpm --parallel --filter \"./**\" serve",
+    "build": "pnpm --parallel --filter \"./**\" --filter \"!.\" build ",
+    "serve": "pnpm --parallel --filter \"./**\" --filter \"!.\" serve",
     "build:remotes": "pnpm --parallel --filter \"./remote\"  build",
     "serve:remotes": "pnpm --parallel --filter \"./remote\"  serve",
     "dev:hosts": "pnpm --filter \"./host\" dev",

--- a/packages/examples/vue3-demo-esm-shared-store/package.json
+++ b/packages/examples/vue3-demo-esm-shared-store/package.json
@@ -8,8 +8,8 @@
     "remote-B"
   ],
   "scripts": {
-    "build": "pnpm --parallel --filter \"./**\" build ",
-    "serve": "pnpm --parallel --filter \"./**\" serve",
+    "build": "pnpm --parallel --filter \"./**\" --filter \"!.\" build ",
+    "serve": "pnpm --parallel --filter \"./**\" --filter \"!.\" serve",
     "build:remotes": "pnpm --parallel --filter \"./remote-A\" --filter \"./remote-B\"  build",
     "serve:remotes": "pnpm --parallel --filter \"./remote-A\" --filter \"./remote-B\"  serve",
     "dev:hosts": "pnpm --filter \"./host\" dev",

--- a/packages/examples/vue3-demo-esm/package.json
+++ b/packages/examples/vue3-demo-esm/package.json
@@ -10,8 +10,8 @@
     "dynamic-remote"
   ],
   "scripts": {
-    "build": "pnpm --parallel --filter \"./**\" build ",
-    "serve": "pnpm --parallel --filter \"./**\" serve",
+    "build": "pnpm --parallel --filter \"./**\" --filter \"!.\" build ",
+    "serve": "pnpm --parallel --filter \"./**\" --filter \"!.\" serve",
     "build:remotes": "pnpm --parallel --filter \"./home\" --filter \"./css-modules\" --filter \"./common-lib\" --filter \"./dynamic-remote\"  build",
     "serve:remotes": "pnpm --parallel --filter \"./home\" --filter \"./css-modules\" --filter \"./common-lib\" --filter \"./dynamic-remote\"  serve",
     "dev:hosts": "pnpm --filter \"./layout\" dev",

--- a/packages/examples/vue3-demo-webpack-esm-esm/package.json
+++ b/packages/examples/vue3-demo-webpack-esm-esm/package.json
@@ -2,8 +2,8 @@
   "name": "vue3-demo-webpack-esm-esm",
   "private": true,
   "scripts": {
-    "build": "pnpm --parallel --filter \"./**\" build",
-    "serve": "pnpm --parallel --filter \"./**\"  serve",
+    "build": "pnpm --parallel --filter \"./**\" --filter \"!.\" build",
+    "serve": "pnpm --parallel --filter \"./**\" --filter \"!.\"  serve",
     "stop": "kill-port --port 5000,5001"
   },
   "workspaces": [

--- a/packages/examples/vue3-demo-webpack-esm-var/package.json
+++ b/packages/examples/vue3-demo-webpack-esm-var/package.json
@@ -2,8 +2,8 @@
   "name": "vue3-demo-webpack-esm-var",
   "private": true,
   "scripts": {
-    "build": "pnpm --parallel --filter \"./**\" build ",
-    "serve": "pnpm --parallel --filter \"./**\" serve",
+    "build": "pnpm --parallel --filter \"./**\" --filter \"!.\" build ",
+    "serve": "pnpm --parallel --filter \"./**\" --filter \"!.\" serve",
     "build:remotes": "pnpm --parallel --filter \"./home\"  build",
     "serve:remotes": "pnpm --parallel --filter \"./home\"  serve",
     "dev:hosts": "pnpm --filter \"./layout\" dev",

--- a/packages/examples/webpack-host/package.json
+++ b/packages/examples/webpack-host/package.json
@@ -2,8 +2,8 @@
   "name": "webpack-host",
   "private": true,
   "scripts": {
-    "build": "pnpm --parallel --filter \"./**\" build",
-    "serve": "pnpm --parallel --filter \"./**\" serve ",
+    "build": "pnpm --parallel --filter \"./**\" --filter \"!.\" build",
+    "serve": "pnpm --parallel --filter \"./**\" --filter \"!.\" serve ",
     "build:remotes": "pnpm --filter \"./remote\"  build",
     "serve:remotes": "pnpm --filter \"./remote\"  serve",
     "dev:hosts": "pnpm --filter \"./host\" dev",


### PR DESCRIPTION
- Add --filter "!." to all example build/serve scripts using --filter "./**" to prevent infinite recursive builds on Windows (pnpm matches root package on Windows but not Linux)
- Track and await server processes in afterAll for clean shutdown
- Kill ports before temp dir cleanup with retry on Windows
- Gitignore temp-* directoriesQ