### PR TITLE
fix: fall back to static export analysis for browser-only shared modules

### DIFF
--- a/packages/lib/src/debug.ts
+++ b/packages/lib/src/debug.ts
@@ -1,0 +1,39 @@
+/**
+ * Inline debug snippets for emitted runtime code.
+ *
+ * These follow the same convention as the `debug` npm package:
+ * enable in the browser with `localStorage.debug = 'federation:*'`
+ * and in Node.js with `DEBUG=federation:* node ...`.
+ *
+ * Each snippet defines a `__fed_debug(namespace)` factory that returns
+ * a log function. The log function is a no-op when the namespace isn't
+ * enabled.
+ */
+
+/** CJS snippet for shim files (runs in Vite's dep optimizer / browser) */
+export const FEDERATION_DEBUG_SNIPPET_CJS = `\
+var __fed_debug = (function() {
+  var pattern;
+  try { pattern = (typeof localStorage !== 'undefined' && localStorage.debug) || ''; } catch(e) { pattern = ''; }
+  return function(ns) {
+    if (!pattern) return function() {};
+    var re = new RegExp('^' + pattern.replace(/\\*/g, '.*?') + '$');
+    if (!re.test(ns)) return function() {};
+    return function() { console.debug.apply(console, ['%c' + ns, 'color: #d97706'].concat(Array.prototype.slice.call(arguments))); };
+  };
+})();
+`
+
+/** ESM snippet for virtual modules (runs in the browser via Vite dev server) */
+export const FEDERATION_DEBUG_SNIPPET_ESM = `\
+const __fed_debug = (() => {
+  let pattern;
+  try { pattern = (typeof localStorage !== 'undefined' && localStorage.debug) || ''; } catch(e) { pattern = ''; }
+  return (ns) => {
+    if (!pattern) return () => {};
+    const re = new RegExp('^' + pattern.replace(/\\*/g, '.*?') + '$');
+    if (!re.test(ns)) return () => {};
+    return (...args) => console.debug('%c' + ns, 'color: #d97706', ...args);
+  };
+})();
+`

--- a/packages/lib/src/dev/expose-development.ts
+++ b/packages/lib/src/dev/expose-development.ts
@@ -26,6 +26,7 @@ import { join, resolve } from 'path'
 import { createRequire } from 'module'
 import { execSync } from 'child_process'
 import type { UserConfig } from 'vite'
+import { FEDERATION_DEBUG_SNIPPET_CJS, FEDERATION_DEBUG_SNIPPET_ESM } from '../debug'
 
 /**
  * Statically extract ESM export names from a file using es-module-lexer,
@@ -139,9 +140,9 @@ const generateShimDir = (
     const shimFile = join(shimDir, `${safeName}.cjs`)
 
     if (!isEsm) {
-      const shimCode = `
+      const shimCode = `${FEDERATION_DEBUG_SNIPPET_CJS}var _log = __fed_debug('federation:shim');
 var mod = globalThis.__federation_shared_modules__ && globalThis.__federation_shared_modules__['${name}'];
-console.log('[federation-shim] ${name}:', mod ? 'SHARED' : 'LOCAL', new Error().stack.split('\\n').slice(0,4).join(' <- '));
+_log('${name}:', mod ? 'SHARED' : 'LOCAL');
 if (mod) {
   module.exports = mod;
 } else {
@@ -157,9 +158,9 @@ if (mod) {
         // globals like `window` at the top level and can't be loaded in
         // Node).  Fall back to a CJS-style shim — the dep optimizer
         // will wrap consumers with __toESM() which is fine.
-        const shimCode = `
+        const shimCode = `${FEDERATION_DEBUG_SNIPPET_CJS}var _log = __fed_debug('federation:shim');
 var mod = globalThis.__federation_shared_modules__ && globalThis.__federation_shared_modules__['${name}'];
-console.log('[federation-shim] ${name}:', mod ? 'SHARED' : 'LOCAL', new Error().stack.split('\\n').slice(0,4).join(' <- '));
+_log('${name}:', mod ? 'SHARED' : 'LOCAL');
 if (mod) {
   module.exports = mod;
 } else {
@@ -171,8 +172,9 @@ if (mod) {
         const namedExports = exportNames.filter((n) => n !== 'default')
         const hasDefault = exportNames.includes('default')
 
-        let shimCode = `var _shared = globalThis.__federation_shared_modules__ && globalThis.__federation_shared_modules__['${name}'];\n`
-        shimCode += `console.log('[federation-shim] ${name}:', _shared ? 'SHARED' : 'LOCAL', new Error().stack.split('\\n').slice(0,4).join(' <- '));\n`
+        let shimCode = `${FEDERATION_DEBUG_SNIPPET_CJS}var _log = __fed_debug('federation:shim');\n`
+        shimCode += `var _shared = globalThis.__federation_shared_modules__ && globalThis.__federation_shared_modules__['${name}'];\n`
+        shimCode += `_log('${name}:', _shared ? 'SHARED' : 'LOCAL');\n`
         shimCode += `var _mod = _shared || require('${escapedPath}');\n`
         if (hasDefault) {
           shimCode += `Object.defineProperty(exports, 'default', { enumerable: true, get: function() { return _mod.default ?? _mod; } });\n`
@@ -222,6 +224,9 @@ export const devExposePlugin = (
     name: 'hugs7:expose-development',
     virtualFile: {
       [`__remoteEntryHelper__${options.filename}`]: `
+${FEDERATION_DEBUG_SNIPPET_ESM}
+const _logInit = __fed_debug('federation:init');
+const _logGet = __fed_debug('federation:get');
 const currentImports = {}
 const exportSet = new Set(['Module', '__esModule', 'default', '_export_sfc']);
 let moduleMap = {${moduleMap}}
@@ -253,7 +258,7 @@ export const init =(shareScope) => {
   if (!globalThis.__federation_shared_modules__) {
     globalThis.__federation_shared_modules__ = {};
   }
-  console.log('[federation-init] Resolving shared modules:', Object.keys(shareScope));
+  _logInit('Resolving shared modules:', Object.keys(shareScope));
   __federation_shared_resolving = Promise.all(Object.keys(shareScope).map(async (key) => {
     try {
       const versions = shareScope[key];
@@ -262,10 +267,10 @@ export const init =(shareScope) => {
         const factory = await versions[ver].get();
         const mod = await factory();
         globalThis.__federation_shared_modules__[key] = mod;
-        console.log('[federation-init] Resolved:', key, Object.keys(mod).slice(0,5));
+        _logInit('Resolved:', key, Object.keys(mod).slice(0,5));
       }
     } catch(e) {
-      console.warn('[federation-dev] Failed to pre-resolve shared module:', key, e);
+      _logInit('Failed to pre-resolve shared module:', key, e);
     }
   }));
 
@@ -286,7 +291,7 @@ export const init =(shareScope) => {
 export const get = async (module) => {
   if (__federation_shared_resolving) await __federation_shared_resolving;
   if (__federation_dev_client_loaded) await __federation_dev_client_loaded;
-  console.log('[federation-get]', module, 'shared modules populated:', Object.keys(globalThis.__federation_shared_modules__ || {}));
+  _logGet(module, 'shared modules populated:', Object.keys(globalThis.__federation_shared_modules__ || {}));
   if(!moduleMap[module]) throw new Error('Can not find remote module ' + module)
   return moduleMap[module]();
 };`

--- a/packages/lib/src/dev/expose-development.ts
+++ b/packages/lib/src/dev/expose-development.ts
@@ -27,13 +27,58 @@ import { createRequire } from 'module'
 import { execSync } from 'child_process'
 import type { UserConfig } from 'vite'
 
+/**
+ * Statically extract ESM export names from a file using es-module-lexer,
+ * run in a subprocess so the async `init()` can complete before `parse()`.
+ * This doesn't execute the module, so it works even when the module
+ * references browser-only globals like `window` at the top level.
+ */
+function getExportNamesStatically(resolvedPath: string): string[] {
+  try {
+    // Pass the file path via argv to avoid shell quoting issues.
+    // es-module-lexer exports may be strings (v0.x) or objects with .n (v1+),
+    // so we normalise both.
+    const script = [
+      "const{init,parse}=require('es-module-lexer');",
+      "const fs=require('fs');",
+      "init.then(()=>{",
+        "const code=fs.readFileSync(process.argv[1],'utf-8');",
+        "const[,exp]=parse(code);",
+        "const names=exp.map(e=>typeof e==='string'?e:e.n).filter(Boolean);",
+        "console.log(JSON.stringify(names));",
+      "});"
+    ].join('')
+    const result = execSync(`node -e "${script}" -- "${resolvedPath}"`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    return JSON.parse(result.trim())
+  } catch {
+    return []
+  }
+}
+
 function getModuleExportNames(name: string, root: string): string[] {
+  // First, try dynamic import() in a subprocess — this gives the most
+  // accurate picture since it evaluates the module.
   try {
     const result = execSync(
       `node --input-type=module -e "import('${name}').then(m => console.log(JSON.stringify(Object.keys(m))))"`,
       { cwd: root, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
     )
     return JSON.parse(result.trim())
+  } catch {
+    // Dynamic import failed — likely because the module references
+    // browser-only globals (e.g. `window`) at the top level.
+    // Fall back to static analysis of the ESM source.
+  }
+
+  // Resolve the module entry point and parse it statically
+  try {
+    const nodeRequire = createRequire(join(root, 'package.json'))
+    const resolvedPath = nodeRequire.resolve(name)
+    return getExportNamesStatically(resolvedPath)
   } catch {
     return []
   }

--- a/packages/lib/src/dev/expose-development.ts
+++ b/packages/lib/src/dev/expose-development.ts
@@ -33,7 +33,7 @@ import type { UserConfig } from 'vite'
  * This doesn't execute the module, so it works even when the module
  * references browser-only globals like `window` at the top level.
  */
-function getExportNamesStatically(resolvedPath: string): string[] {
+const getExportNamesStatically = (resolvedPath: string): string[] => {
   try {
     // Pass the file path via argv to avoid shell quoting issues.
     // es-module-lexer exports may be strings (v0.x) or objects with .n (v1+),
@@ -59,7 +59,7 @@ function getExportNamesStatically(resolvedPath: string): string[] {
   }
 }
 
-function getModuleExportNames(name: string, root: string): string[] {
+const getModuleExportNames = (name: string, root: string): string[] => {
   // First, try dynamic import() in a subprocess — this gives the most
   // accurate picture since it evaluates the module.
   try {
@@ -88,10 +88,10 @@ function getModuleExportNames(name: string, root: string): string[] {
 // optimizer bundles them instead of the real packages.  Every optimized
 // dep (react-redux, etc.) that imports "react" will therefore go through
 // the bridge, which reads from the federation share scope at runtime.
-function generateShimDir(
+const generateShimDir = (
   sharedNames: string[],
   root: string
-): { shimDir: string; aliases: Record<string, string> } {
+): { shimDir: string; aliases: Record<string, string> } => {
   const shimDir = join(root, 'node_modules', '.federation-shims')
   if (!existsSync(shimDir)) {
     mkdirSync(shimDir, { recursive: true })
@@ -193,7 +193,7 @@ if (mod) {
 // Convert an absolute filesystem path to a URL that Vite's dev server
 // can serve.  If the path is inside the project root, return a root-
 // relative path; otherwise use /@fs/ prefix.
-function toViteUrl(filePath: string, root: string): string {
+const toViteUrl = (filePath: string, root: string): string => {
   const normalized = filePath.replace(/\\/g, '/')
   const normalizedRoot = root.replace(/\\/g, '/').replace(/\/$/, '')
   if (normalized.startsWith(normalizedRoot + '/')) {
@@ -202,9 +202,9 @@ function toViteUrl(filePath: string, root: string): string {
   return `/@fs${normalized}`
 }
 
-export function devExposePlugin(
+export const devExposePlugin = (
   options: VitePluginFederationOptions
-): PluginHooks {
+): PluginHooks => {
   parsedOptions.devExpose = parseExposeOptions(options)
 
   // Build list of shared module names for init code generation

--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -31,9 +31,9 @@ import {
 import { builderInfo, parsedOptions, devRemotes } from '../public'
 import type { PluginHooks } from '../../types/pluginHooks'
 
-export function devRemotePlugin(
+export const devRemotePlugin = (
   options: VitePluginFederationOptions
-): PluginHooks {
+): PluginHooks => {
   parsedOptions.devRemote = parseRemoteOptions(options)
   // const remotes: { id: string; regexp: RegExp; config: RemotesConfig }[] = []
   for (const item of parsedOptions.devRemote) {

--- a/packages/lib/src/dev/shared-development.ts
+++ b/packages/lib/src/dev/shared-development.ts
@@ -18,9 +18,9 @@ import { parseSharedOptions } from '../utils'
 import { parsedOptions } from '../public'
 import type { VitePluginFederationOptions } from 'types'
 
-export function devSharedPlugin(
+export const devSharedPlugin = (
   options: VitePluginFederationOptions
-): PluginHooks {
+): PluginHooks => {
   parsedOptions.devShared = parseSharedOptions(options)
 
   return {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -34,9 +34,9 @@ import { devSharedPlugin } from './dev/shared-development'
 import { devRemotePlugin } from './dev/remote-development'
 import { devExposePlugin } from './dev/expose-development'
 
-export default function federation(
+const federation = (
   options: VitePluginFederationOptions
-): Plugin {
+): Plugin => {
   options.filename = options.filename
     ? options.filename
     : DEFAULT_ENTRY_FILENAME
@@ -45,7 +45,7 @@ export default function federation(
   let virtualMod
   let registerCount = 0
 
-  function registerPlugins(mode: string, command: string) {
+  const registerPlugins = (mode: string, command: string) => {
     if (mode === 'production' || command === 'build') {
       pluginList = [
         prodSharedPlugin(options),
@@ -215,3 +215,5 @@ export default function federation(
     }
   }
 }
+
+export default federation

--- a/packages/lib/src/prod/expose-production.ts
+++ b/packages/lib/src/prod/expose-production.ts
@@ -39,9 +39,9 @@ import MagicString from 'magic-string'
 import { walk } from 'estree-walker'
 import type { ResolvedConfig } from 'vite'
 
-export function prodExposePlugin(
+export const prodExposePlugin = (
   options: VitePluginFederationOptions
-): PluginHooks {
+): PluginHooks => {
   let moduleMap = ''
   const hasOptions = parsedOptions.prodExpose.some((expose) => {
     return expose[0] === parseExposeOptions(options)[0]?.[0]

--- a/packages/lib/src/prod/federation_fn_import.js
+++ b/packages/lib/src/prod/federation_fn_import.js
@@ -1,5 +1,17 @@
 import { satisfy } from '__federation_fn_satisfy'
 
+const __fed_debug = (() => {
+  let pattern;
+  try { pattern = (typeof localStorage !== 'undefined' && localStorage.debug) || ''; } catch(e) { pattern = ''; } // eslint-disable-line no-undef
+  return (ns) => {
+    if (!pattern) return () => {};
+    const re = new RegExp('^' + pattern.replace(/\*/g, '.*?') + '$');
+    if (!re.test(ns)) return () => {};
+    return (...args) => console.debug('%c' + ns, 'color: #d97706', ...args);
+  };
+})();
+const _log = __fed_debug('federation:shared');
+
 const currentImports = {}
 
 // eslint-disable-next-line no-undef
@@ -32,10 +44,10 @@ async function getSharedFromRuntime(name, shareScope) {
         const versionValue = versionObj[versionKey]
         module = await (await versionValue.get())()
       } else {
-        console.log(
-          `provider support ${name} is not satisfied requiredVersion(${moduleMap[name].requiredVersion}). Debug logging will show available modules and versions.`
+        _log(
+          `provider support ${name} is not satisfied requiredVersion(${moduleMap[name].requiredVersion}).`,
+          moduleMap
         )
-        console.debug(moduleMap)
       }
     } else {
       const versionKey = Object.keys(versionObj)[0]

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -45,7 +45,7 @@ const sharedFileName2Prop: Map<string, ConfigTypeSet> = new Map<
   ConfigTypeSet
 >()
 
-function joinUrlSegments(a: string, b: string): string {
+const joinUrlSegments = (a: string, b: string): string => {
   if (!a || !b) {
     return a || b || ''
   }
@@ -58,14 +58,14 @@ function joinUrlSegments(a: string, b: string): string {
   return a + b
 }
 
-function toOutputFilePathWithoutRuntime(
+const toOutputFilePathWithoutRuntime = (
   filename: string,
   type: 'asset' | 'public',
   hostId: string,
   hostType: 'js' | 'css' | 'html',
   config: ResolvedConfig,
   toRelative: (filename: string, hostId: string) => string
-): string {
+): string => {
   const { renderBuiltUrl } = config.experimental
   let relative = config.base === '' || config.base === './'
   if (renderBuiltUrl) {
@@ -95,9 +95,9 @@ function toOutputFilePathWithoutRuntime(
   }
 }
 
-export function prodRemotePlugin(
+export const prodRemotePlugin = (
   options: VitePluginFederationOptions
-): PluginHooks {
+): PluginHooks => {
   parsedOptions.prodRemote = parseRemoteOptions(options)
   // const remotes: Remote[] = []
   for (const item of parsedOptions.prodRemote) {

--- a/packages/lib/src/prod/shared-production.ts
+++ b/packages/lib/src/prod/shared-production.ts
@@ -22,9 +22,9 @@ import { readdirSync, readFileSync, statSync } from 'fs'
 const sharedFilePathReg = /__federation_shared_(.+)-.{8}\.js$/
 import federation_fn_import from './federation_fn_import.js?raw'
 
-export function prodSharedPlugin(
+export const prodSharedPlugin = (
   options: VitePluginFederationOptions
-): PluginHooks {
+): PluginHooks => {
   parsedOptions.prodShared = parseSharedOptions(options)
   const shareName2Prop = new Map<string, any>()
   parsedOptions.prodShared.forEach((value) =>

--- a/packages/lib/src/utils/html.ts
+++ b/packages/lib/src/utils/html.ts
@@ -10,10 +10,10 @@ export interface HtmlTagDescriptor {
 
 const unaryTags = new Set(['link', 'meta', 'base'])
 
-function serializeTag(
+const serializeTag = (
   { tag, attrs, children }: HtmlTagDescriptor,
   indent = ''
-): string {
+): string => {
   if (unaryTags.has(tag)) {
     return `<${tag}${serializeAttrs(attrs)}>`
   } else {
@@ -24,10 +24,10 @@ function serializeTag(
   }
 }
 
-function serializeTags(
+const serializeTags = (
   tags: HtmlTagDescriptor['children'],
   indent = ''
-): string {
+): string => {
   if (typeof tags === 'string') {
     return tags
   } else if (tags && tags.length) {
@@ -36,7 +36,7 @@ function serializeTags(
   return ''
 }
 
-function serializeAttrs(attrs: HtmlTagDescriptor['attrs']): string {
+const serializeAttrs = (attrs: HtmlTagDescriptor['attrs']): string => {
   let res = ''
   for (const key in attrs) {
     if (typeof attrs[key] === 'boolean') {
@@ -48,13 +48,13 @@ function serializeAttrs(attrs: HtmlTagDescriptor['attrs']): string {
   return res
 }
 
-function incrementIndent(indent = '') {
+const incrementIndent = (indent = '') => {
   return `${indent}${indent[0] === '\t' ? '\t' : '  '}`
 }
 
 const matchHtmlRegExp = /["'&<>]/
 
-function escapeHtml(string: any) {
+const escapeHtml = (string: any) => {
   const str = '' + string
   const match = matchHtmlRegExp.exec(str)
 
@@ -117,11 +117,11 @@ export const toPreloadTag = (href: string): HtmlTagDescriptor => ({
   }
 })
 
-export function injectToHead(
+export const injectToHead = (
   html: string,
   tags: HtmlTagDescriptor[],
   prepend = false
-) {
+) => {
   if (tags.length === 0) return html
 
   if (prepend) {
@@ -153,7 +153,7 @@ export function injectToHead(
   return prependInjectFallback(html, tags)
 }
 
-function prependInjectFallback(html: string, tags: HtmlTagDescriptor[]) {
+const prependInjectFallback = (html: string, tags: HtmlTagDescriptor[]) => {
   // prepend to the html tag, append after doctype, or the document start
   if (htmlPrependInjectRE.test(html)) {
     return html.replace(htmlPrependInjectRE, `$&\n${serializeTags(tags)}`)

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -54,9 +54,9 @@ export function findDependencies(
   }
 }
 
-export function parseSharedOptions(
+export const parseSharedOptions = (
   options: VitePluginFederationOptions
-): (string | ConfigTypeSet)[] {
+): (string | ConfigTypeSet)[] => {
   return parseOptions(
     options.shared || {},
     (value, key) => ({
@@ -80,9 +80,9 @@ export function parseSharedOptions(
   )
 }
 
-export function parseExposeOptions(
+export const parseExposeOptions = (
   options: VitePluginFederationOptions
-): (string | ConfigTypeSet)[] {
+): (string | ConfigTypeSet)[] => {
   return parseOptions(
     options.exposes,
     (item) => {
@@ -100,14 +100,14 @@ export function parseExposeOptions(
   )
 }
 
-export function createContentHash(path: string): string {
+export const createContentHash = (path: string): string => {
   const content = readFileSync(path, { encoding: 'utf-8' })
   return createHash('md5').update(content).digest('hex').toString().slice(0, 8)
 }
 
-export function parseRemoteOptions(
+export const parseRemoteOptions = (
   options: VitePluginFederationOptions
-): (string | ConfigTypeSet)[] {
+): (string | ConfigTypeSet)[] => {
   return parseOptions(
     options.remotes ? options.remotes : {},
     (item) => ({
@@ -127,11 +127,11 @@ export function parseRemoteOptions(
   )
 }
 
-export function parseOptions(
+export const parseOptions = (
   options: Exposes | Remotes | Shared | undefined,
   normalizeSimple: (value: any, key: any) => ConfigTypeSet,
   normalizeOptions: (value: any, key: any) => ConfigTypeSet
-): (string | ConfigTypeSet)[] {
+): (string | ConfigTypeSet)[] => {
   if (!options) {
     return []
   }
@@ -170,7 +170,7 @@ export function parseOptions(
 
 const letterReg = new RegExp('[0-9a-zA-Z]+')
 
-export function removeNonRegLetter(str: string, reg = letterReg): string {
+export const removeNonRegLetter = (str: string, reg = letterReg): string => {
   let needUpperCase = false
   let ret = ''
   for (const c of str) {
@@ -184,19 +184,19 @@ export function removeNonRegLetter(str: string, reg = letterReg): string {
   return ret
 }
 
-export function getModuleMarker(value: string, type?: string): string {
+export const getModuleMarker = (value: string, type?: string): string => {
   return type ? `__rf_${type}__${value}` : `__rf_placeholder__${value}`
 }
 
-export function normalizePath(id: string): string {
+export const normalizePath = (id: string): string => {
   return posix.normalize(id.replace(/\\/g, '/'))
 }
 
-export function uniqueArr<T>(arr: T[]): T[] {
+export const uniqueArr = <T>(arr: T[]): T[] => {
   return Array.from(new Set(arr))
 }
 
-export function isSameFilepath(src: string, dest: string): boolean {
+export const isSameFilepath = (src: string, dest: string): boolean => {
   if (!src || !dest) {
     return false
   }
@@ -218,7 +218,7 @@ export function isSameFilepath(src: string, dest: string): boolean {
 
 export type Remote = { id: string; regexp: RegExp; config: RemotesConfig }
 
-export function createRemotesMap(remotes: Remote[]): string {
+export const createRemotesMap = (remotes: Remote[]): string => {
   const createUrl = (remote: Remote) => {
     const external = remote.config.external[0]
     const externalType = remote.config.externalType
@@ -244,7 +244,7 @@ ${remotes
  * get file extname from url
  * @param url
  */
-export function getFileExtname(url: string): string {
+export const getFileExtname = (url: string): string => {
   const fileNameAndParamArr = normalizePath(url).split('/')
   const fileNameAndParam = fileNameAndParamArr[fileNameAndParamArr.length - 1]
   const fileName = fileNameAndParam.split('?')[0]


### PR DESCRIPTION
When a shared module references browser-only globals (e.g. window) at the top level, the dynamic import() in getModuleExportNames fails in Node.js and returns no exports. This causes the CJS shim to use a generic module.exports fallback that loses named exports, breaking consumers that import specific symbols (e.g. ALLOWED_IDP_PROVIDERS).

Add getExportNamesStatically() which uses es-module-lexer to parse export names from the ESM source file without executing it. The dynamic import is still tried first for accuracy; static analysis is only used as a fallback.