### PR TITLE
fix: resolve duplicate React instances in federated remotes

### DIFF
--- a/packages/lib/src/dev/expose-development.ts
+++ b/packages/lib/src/dev/expose-development.ts
@@ -13,19 +13,15 @@
 // SPDX-License-Identifier: MulanPSL-2.0
 // *****************************************************************************
 
-import {
-  parseExposeOptions,
-  removeNonRegLetter,
-  NAME_CHAR_REG
-} from '../utils'
-import { parsedOptions } from '../public'
-import type { VitePluginFederationOptions } from 'types'
-import type { PluginHooks } from '../../types/pluginHooks'
-import { existsSync, readFileSync as fsReadFileSync } from 'fs'
-import { join, resolve } from 'path'
-import { createRequire } from 'module'
 import { execSync } from 'child_process'
+import { createRequire } from 'module'
+import { join, resolve } from 'path'
+import type { VitePluginFederationOptions } from 'types'
 import type { UserConfig } from 'vite'
+import type { PluginHooks } from '../../types/pluginHooks'
+import { parsedOptions } from '../public'
+import { NAME_CHAR_REG, parseExposeOptions, removeNonRegLetter } from '../utils'
+
 import { FEDERATION_DEBUG_SNIPPET_ESM } from '../debug'
 
 const SHARED_VIRTUAL_PREFIX = 'virtual:__federation_shared__:'
@@ -42,12 +38,12 @@ const getExportNamesStatically = (resolvedPath: string): string[] => {
     const script = [
       "const{init,parse}=require('es-module-lexer');",
       "const fs=require('fs');",
-      "init.then(()=>{",
-        "const code=fs.readFileSync(process.argv[1],'utf-8');",
-        "const[,exp]=parse(code);",
-        "const names=exp.map(e=>typeof e==='string'?e:e.n).filter(Boolean);",
-        "console.log(JSON.stringify(names));",
-      "});"
+      'init.then(()=>{',
+      "const code=fs.readFileSync(process.argv[1],'utf-8');",
+      'const[,exp]=parse(code);',
+      "const names=exp.map(e=>typeof e==='string'?e:e.n).filter(Boolean);",
+      'console.log(JSON.stringify(names));',
+      '});'
     ].join('')
     const result = execSync(`node -e "${script}" -- "${resolvedPath}"`, {
       encoding: 'utf-8',
@@ -64,7 +60,12 @@ const getModuleExportNames = (name: string, root: string): string[] => {
   try {
     const result = execSync(
       `node --input-type=module -e "import('${name}').then(m => console.log(JSON.stringify(Object.keys(m))))"`,
-      { cwd: root, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }
+      {
+        cwd: root,
+        encoding: 'utf-8',
+        timeout: 10000,
+        stdio: ['pipe', 'pipe', 'pipe']
+      }
     )
     return JSON.parse(result.trim())
   } catch {
@@ -93,13 +94,19 @@ interface SharedModuleMeta {
  * At runtime, checks globalThis.__federation_shared_modules__ first (set by
  * the host's init()), falling back to a dynamic import of the local package.
  */
-function buildSharedWrapperCode(name: string, meta: SharedModuleMeta): string {
+const buildSharedWrapperCode = (
+  name: string,
+  meta: SharedModuleMeta
+): string => {
   const named = meta.exports.filter((e) => e !== 'default')
   const hasDefault = meta.exports.includes('default')
 
   // Use the base shared module name for the globalThis lookup
   // (e.g. 'react' for both 'react' and 'react/jsx-runtime')
-  const baseName = name.split('/').slice(0, name.startsWith('@') ? 2 : 1).join('/')
+  const baseName = name
+    .split('/')
+    .slice(0, name.startsWith('@') ? 2 : 1)
+    .join('/')
   const isSubPath = name !== baseName
 
   let code = ''
@@ -260,7 +267,6 @@ export const get = async (module) => {
         const exports = getModuleExportNames(name, root)
         sharedModuleMeta.set(name, { localUrl, exports })
       }
-
     },
 
     resolveId(id: string) {
@@ -285,7 +291,10 @@ export const get = async (module) => {
         return null
       }
 
-      return { code: buildSharedWrapperCode(specifier, meta), moduleType: 'js' as const }
+      return {
+        code: buildSharedWrapperCode(specifier, meta),
+        moduleType: 'js' as const
+      }
     },
     configureServer(server) {
       // Add CORS headers to ALL responses so the HOST browser can load
@@ -407,7 +416,10 @@ export default { injectIntoGlobalHook: _rt.injectIntoGlobalHook };
 
         // Serve the real react-refresh runtime under an alternate
         // URL so the /@react-refresh wrapper can import it.
-        if (url === '/@react-refresh-runtime' || url?.startsWith('/@react-refresh-runtime?')) {
+        if (
+          url === '/@react-refresh-runtime' ||
+          url?.startsWith('/@react-refresh-runtime?')
+        ) {
           try {
             const result = await server.transformRequest('/@react-refresh')
             if (result) {
@@ -415,7 +427,9 @@ export default { injectIntoGlobalHook: _rt.injectIntoGlobalHook };
               res.end(result.code)
               return
             }
-          } catch { /* fall through */ }
+          } catch {
+            /* fall through */
+          }
           next()
           return
         }

--- a/packages/lib/src/dev/expose-development.ts
+++ b/packages/lib/src/dev/expose-development.ts
@@ -21,12 +21,15 @@ import {
 import { parsedOptions } from '../public'
 import type { VitePluginFederationOptions } from 'types'
 import type { PluginHooks } from '../../types/pluginHooks'
-import { mkdirSync, writeFileSync, existsSync, readFileSync as fsReadFileSync } from 'fs'
+import { existsSync, readFileSync as fsReadFileSync } from 'fs'
 import { join, resolve } from 'path'
 import { createRequire } from 'module'
 import { execSync } from 'child_process'
 import type { UserConfig } from 'vite'
-import { FEDERATION_DEBUG_SNIPPET_CJS, FEDERATION_DEBUG_SNIPPET_ESM } from '../debug'
+import { FEDERATION_DEBUG_SNIPPET_ESM } from '../debug'
+
+const SHARED_VIRTUAL_PREFIX = 'virtual:__federation_shared__:'
+const RESOLVED_SHARED_PREFIX = '\0' + SHARED_VIRTUAL_PREFIX
 
 /**
  * Statically extract ESM export names from a file using es-module-lexer,
@@ -36,9 +39,6 @@ import { FEDERATION_DEBUG_SNIPPET_CJS, FEDERATION_DEBUG_SNIPPET_ESM } from '../d
  */
 const getExportNamesStatically = (resolvedPath: string): string[] => {
   try {
-    // Pass the file path via argv to avoid shell quoting issues.
-    // es-module-lexer exports may be strings (v0.x) or objects with .n (v1+),
-    // so we normalise both.
     const script = [
       "const{init,parse}=require('es-module-lexer');",
       "const fs=require('fs');",
@@ -61,8 +61,6 @@ const getExportNamesStatically = (resolvedPath: string): string[] => {
 }
 
 const getModuleExportNames = (name: string, root: string): string[] => {
-  // First, try dynamic import() in a subprocess — this gives the most
-  // accurate picture since it evaluates the module.
   try {
     const result = execSync(
       `node --input-type=module -e "import('${name}').then(m => console.log(JSON.stringify(Object.keys(m))))"`,
@@ -70,12 +68,9 @@ const getModuleExportNames = (name: string, root: string): string[] => {
     )
     return JSON.parse(result.trim())
   } catch {
-    // Dynamic import failed — likely because the module references
-    // browser-only globals (e.g. `window`) at the top level.
-    // Fall back to static analysis of the ESM source.
+    // Dynamic import failed — fall back to static analysis
   }
 
-  // Resolve the module entry point and parse it statically
   try {
     const nodeRequire = createRequire(join(root, 'package.json'))
     const resolvedPath = nodeRequire.resolve(name)
@@ -85,112 +80,54 @@ const getModuleExportNames = (name: string, root: string): string[] => {
   }
 }
 
-// Generate bridge/shim files for shared modules so that Vite's dep
-// optimizer bundles them instead of the real packages.  Every optimized
-// dep (react-redux, etc.) that imports "react" will therefore go through
-// the bridge, which reads from the federation share scope at runtime.
-const generateShimDir = (
-  sharedNames: string[],
-  root: string
-): { shimDir: string; aliases: Record<string, string> } => {
-  const shimDir = join(root, 'node_modules', '.federation-shims')
-  if (!existsSync(shimDir)) {
-    mkdirSync(shimDir, { recursive: true })
+/** Metadata for a shared virtual module */
+interface SharedModuleMeta {
+  /** Vite-serveable URL for the real local module (/@fs/... or root-relative) */
+  localUrl: string
+  /** Enumerated export names */
+  exports: string[]
+}
+
+/**
+ * Build ESM wrapper code for a shared virtual module.
+ * At runtime, checks globalThis.__federation_shared_modules__ first (set by
+ * the host's init()), falling back to a dynamic import of the local package.
+ */
+function buildSharedWrapperCode(name: string, meta: SharedModuleMeta): string {
+  const named = meta.exports.filter((e) => e !== 'default')
+  const hasDefault = meta.exports.includes('default')
+
+  // Use the base shared module name for the globalThis lookup
+  // (e.g. 'react' for both 'react' and 'react/jsx-runtime')
+  const baseName = name.split('/').slice(0, name.startsWith('@') ? 2 : 1).join('/')
+  const isSubPath = name !== baseName
+
+  let code = ''
+
+  if (isSubPath) {
+    // For sub-path imports (e.g. react/jsx-runtime), we can't look them
+    // up in the shared modules map directly. Import from the local package.
+    code += `const __mod = await import(/* @vite-ignore */ ${JSON.stringify(meta.localUrl)});\n`
+  } else {
+    code += `const __shared = globalThis.__federation_shared_modules__?.[${JSON.stringify(name)}];\n`
+    code += `const __mod = __shared ?? await import(/* @vite-ignore */ ${JSON.stringify(meta.localUrl)});\n`
   }
 
-  const aliases: Record<string, string> = {}
-  const nodeRequire = createRequire(join(root, 'package.json'))
-  for (const name of sharedNames) {
-    let realPath: string
-    try {
-      realPath = nodeRequire.resolve(name)
-    } catch {
-      continue
+  if (hasDefault) {
+    code += `export default (__mod.default ?? __mod);\n`
+  }
+  for (const e of named) {
+    // Use safe identifier check — most exports are valid JS identifiers
+    if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(e)) {
+      code += `export const ${e} = __mod[${JSON.stringify(e)}];\n`
     }
-
-    const safeName = name.replace(/[/@]/g, '_')
-    const escapedPath = realPath.replace(/\\/g, '/')
-
-    // Detect if the resolved entry is ESM
-    const isEsm = realPath.endsWith('.mjs') || (() => {
-      try {
-        let dir = realPath
-        while (dir !== join(dir, '..')) {
-          dir = join(dir, '..')
-          const pkgPath = join(dir, 'package.json')
-          if (existsSync(pkgPath)) {
-            return JSON.parse(fsReadFileSync(pkgPath, 'utf-8')).type === 'module'
-          }
-        }
-      } catch {
-        // ignore – fall through to default (false)
-      }
-      return false
-    })()
-
-    // ALL shared modules use CJS shims so they go through the dep
-    // optimizer normally (avoiding CJS transitive dep issues from
-    // optimizeDeps.exclude).
-    //
-    // For CJS packages: require() the real entry directly.
-    // For ESM packages: enumerate exports at build time and emit
-    //   explicit `exports.X = mod.X` lines.  This avoids the dep
-    //   optimizer trying to trace ESM re-export chains through a
-    //   CJS require() wrapper (which causes "export not defined").
-    const shimFile = join(shimDir, `${safeName}.cjs`)
-
-    if (!isEsm) {
-      const shimCode = `${FEDERATION_DEBUG_SNIPPET_CJS}var _log = __fed_debug('federation:shim');
-var mod = globalThis.__federation_shared_modules__ && globalThis.__federation_shared_modules__['${name}'];
-_log('${name}:', mod ? 'SHARED' : 'LOCAL');
-if (mod) {
-  module.exports = mod;
-} else {
-  module.exports = require('${escapedPath}');
-}
-`
-      writeFileSync(shimFile, shimCode)
-    } else {
-      const exportNames = getModuleExportNames(name, root)
-
-      if (!exportNames.length) {
-        // Export enumeration failed (e.g. the module references browser
-        // globals like `window` at the top level and can't be loaded in
-        // Node).  Fall back to a CJS-style shim — the dep optimizer
-        // will wrap consumers with __toESM() which is fine.
-        const shimCode = `${FEDERATION_DEBUG_SNIPPET_CJS}var _log = __fed_debug('federation:shim');
-var mod = globalThis.__federation_shared_modules__ && globalThis.__federation_shared_modules__['${name}'];
-_log('${name}:', mod ? 'SHARED' : 'LOCAL');
-if (mod) {
-  module.exports = mod;
-} else {
-  module.exports = require('${escapedPath}');
-}
-`
-        writeFileSync(shimFile, shimCode)
-      } else {
-        const namedExports = exportNames.filter((n) => n !== 'default')
-        const hasDefault = exportNames.includes('default')
-
-        let shimCode = `${FEDERATION_DEBUG_SNIPPET_CJS}var _log = __fed_debug('federation:shim');\n`
-        shimCode += `var _shared = globalThis.__federation_shared_modules__ && globalThis.__federation_shared_modules__['${name}'];\n`
-        shimCode += `_log('${name}:', _shared ? 'SHARED' : 'LOCAL');\n`
-        shimCode += `var _mod = _shared || require('${escapedPath}');\n`
-        if (hasDefault) {
-          shimCode += `Object.defineProperty(exports, 'default', { enumerable: true, get: function() { return _mod.default ?? _mod; } });\n`
-        }
-        for (const n of namedExports) {
-          const escaped = n.replace(/'/g, "\\'")
-          shimCode += `Object.defineProperty(exports, '${escaped}', { enumerable: true, get: function() { return _mod['${escaped}']; } });\n`
-        }
-        writeFileSync(shimFile, shimCode)
-      }
-    }
-    aliases[name] = shimFile
   }
 
-  return { shimDir, aliases }
+  return code
 }
+
+/** Map of shared specifier -> metadata, populated in config() */
+const sharedModuleMeta = new Map<string, SharedModuleMeta>()
 
 // Convert an absolute filesystem path to a URL that Vite's dev server
 // can serve.  If the path is inside the project root, return a root-
@@ -299,42 +236,56 @@ export const get = async (module) => {
     config(config: UserConfig) {
       resolvedRoot = config.root ? resolve(config.root) : process.cwd()
 
-      // Only set up shims when this is a remote (has exposes) with shared modules
+      // Only set up shared wrappers when this is a remote with shared modules
       if (!parsedOptions.devExpose.length || !parsedOptions.devShared.length) {
         return
       }
 
-      // Populate sharedList from parsed options
-      for (const item of parsedOptions.devShared) {
-        sharedList.push(item[0])
-      }
-
       const root = resolvedRoot
-      const { aliases } = generateShimDir(sharedList, root)
+      const nodeRequire = createRequire(join(root, 'package.json'))
 
-      // Set up resolve aliases so all imports of shared modules (including
-      // from pre-bundled deps) go through the bridge shims
-      if (!config.resolve) config.resolve = {}
-      if (!config.resolve.alias) config.resolve.alias = {}
+      // Populate sharedList and discover exports for each shared module
+      for (const item of parsedOptions.devShared) {
+        const name = item[0]
+        sharedList.push(name)
 
-      // Use array-style aliases with regex for exact matching,
-      // so 'react' doesn't also match 'react/jsx-runtime' or 'react-dom'
-      if (!Array.isArray(config.resolve.alias)) {
-        // Convert object-style to array-style
-        const existing = config.resolve.alias as Record<string, string>
-        config.resolve.alias = Object.entries(existing).map(
-          ([find, replacement]) => ({ find, replacement })
-        )
-      }
-      for (const [from, to] of Object.entries(aliases)) {
-        // Exact match regex: ^react$ matches 'react' but not 'react/jsx-runtime'
-        ;(config.resolve.alias as any[]).push({
-          find: new RegExp(`^${from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`),
-          replacement: to
-        })
+        let realPath: string
+        try {
+          realPath = nodeRequire.resolve(name)
+        } catch {
+          continue
+        }
+
+        const localUrl = toViteUrl(realPath, root)
+        const exports = getModuleExportNames(name, root)
+        sharedModuleMeta.set(name, { localUrl, exports })
       }
 
+    },
 
+    resolveId(id: string) {
+      // Intercept bare shared specifiers so they resolve to virtual wrappers
+      // instead of the real package.  This gives us a single entry point
+      // that can switch between the host's shared module and the local one.
+      if (sharedModuleMeta.has(id)) {
+        return { id: RESOLVED_SHARED_PREFIX + id }
+      }
+
+      return null
+    },
+
+    load(id: string) {
+      if (!id.startsWith(RESOLVED_SHARED_PREFIX)) {
+        return null
+      }
+
+      const specifier = id.slice(RESOLVED_SHARED_PREFIX.length)
+      const meta = sharedModuleMeta.get(specifier)
+      if (!meta) {
+        return null
+      }
+
+      return { code: buildSharedWrapperCode(specifier, meta), moduleType: 'js' as const }
     },
     configureServer(server) {
       // Add CORS headers to ALL responses so the HOST browser can load

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -135,6 +135,14 @@ const federation = (
     },
 
     async resolveId(...args) {
+      // Check sub-plugins first (e.g. shared module virtual resolution)
+      for (const pluginHook of pluginList) {
+        const result = await pluginHook.resolveId?.call(this, ...args)
+        if (result) {
+          return result
+        }
+      }
+
       const v = virtualMod.resolveId.call(this, ...args)
       if (v) {
         return v
@@ -164,6 +172,14 @@ const federation = (
     },
 
     load(...args) {
+      // Check sub-plugins first
+      for (const pluginHook of pluginList) {
+        const result = pluginHook.load?.call(this, ...args)
+        if (result) {
+          return result
+        }
+      }
+
       const v = virtualMod.load.call(this, ...args)
       if (v) {
         return v

--- a/packages/lib/src/prod/remote-production.ts
+++ b/packages/lib/src/prod/remote-production.ts
@@ -320,12 +320,36 @@ export const prodRemotePlugin = (
       }
 
       if (builderInfo.isHost || builderInfo.isShared) {
-        // Skip node_modules: third-party libraries should keep their static
-        // imports. Transforming them to await importShared() creates TLA in
-        // vendor chunks that often contain the shared modules themselves,
-        // causing self-referential deadlocks during module evaluation.
-        if (id.includes('/node_modules/') || id.includes('\\node_modules\\')) {
-          return null
+        const isNodeModules =
+          id.includes('/node_modules/') || id.includes('\\node_modules\\')
+
+        if (isNodeModules) {
+          if (!builderInfo.isRemote) {
+            // Host-only builds: skip node_modules entirely — transforming
+            // them to await importShared() creates TLA in vendor chunks
+            // that often contain the shared modules themselves, causing
+            // self-referential deadlocks during module evaluation.
+            return null
+          }
+
+          // Remote builds: allow the transform for third-party libraries
+          // so their shared-module imports (e.g. react) go through
+          // importShared() — preventing duplicate module instances at
+          // runtime.  However, skip files that belong to a shared module's
+          // own package to avoid self-referential deadlocks (e.g.
+          // react/index.js importing itself via importShared('react')).
+          const normalizedId = id.replace(/\\/g, '/')
+          const isSharedModuleSource = parsedOptions.prodShared.some(
+            (sharedInfo) => {
+              const sharedName = sharedInfo[0]
+              // Match node_modules/<sharedName>/ or node_modules/@scope/pkg/
+              const pattern = `/node_modules/${sharedName}/`
+              return normalizedId.includes(pattern)
+            }
+          )
+          if (isSharedModuleSource) {
+            return null
+          }
         }
 
         let ast: AcornNode | null = null


### PR DESCRIPTION
Production: allow importShared transform to run on node_modules files in remote builds, so third-party libraries (e.g. @westpac/ui) use the shared React instance instead of a separate bundled copy. Files belonging to a shared module's own package are still skipped to prevent self-referential TLA deadlocks.

Dev: replace CJS shim + resolve.alias approach with virtual ESM modules via resolveId + load hooks. Rolldown's dep optimizer inlines CJS require() calls, making the runtime globalThis check dead code. Virtual ESM wrappers preserve the runtime branch and correctly delegate to the host's shared modules when federated, falling back to local import() in standalone mode.
