### PR TITLE
fix: resolve shared module context duplication in dev mode (react-rou…

### DIFF
--- a/packages/lib/src/dev/expose-development.ts
+++ b/packages/lib/src/dev/expose-development.ts
@@ -350,29 +350,72 @@ export const get = async (module) => {
         const meta = sharedModuleMeta.get(name)
         if (!meta || meta.isCjs) continue
 
-        // All non-CJS shared modules should be excluded from dep
-        // optimization so the MFE bundle has bare-specifier imports
-        // that our middleware can intercept.
+        // Non-CJS shared modules should be excluded from dep
+        // optimization so the virtual wrapper intercepts ALL imports
+        // (including from other pre-bundled deps).  When a shared
+        // module stays pre-bundled, other pre-bundled deps import its
+        // internal chunks directly, bypassing the shared wrapper.
         //
-        // For modules with relative imports to internal chunks (e.g.
-        // react-router → ./chunk-XXX.mjs), the chunks may import CJS
-        // packages (cookie, set-cookie-parser).  We force-include those
-        // CJS deps via optimizeDeps.include so Vite pre-bundles them
-        // before the browser needs them.
+        // EXCEPTION: modules whose entry uses `export * from "pkg"`
+        // where pkg is a non-shared CJS module CANNOT be excluded.
+        // `export *` requires the target to have static named exports,
+        // but CJS modules pre-bundled by Vite only have a default
+        // export.  These modules must stay pre-bundled (the dep
+        // optimizer flattens the `export *` during bundling).
+        //
+        // Any non-shared bare-specifier deps are force-included so
+        // the browser can load them from .vite/deps/.
+        let hasExportStarFromNonShared = false
+
+        try {
+          const realPath = nodeRequire.resolve(name)
+          const src = readFileSync(realPath, 'utf-8')
+
+          // Check for `export * from "non-shared-pkg"` in entry
+          const exportStarDeps = [
+            ...src.matchAll(/export\s+\*\s+from\s+['"]([^'"./][^'"]*)['"]/g)
+          ].map((m) => m[1])
+          for (const dep of exportStarDeps) {
+            const pkg = dep.startsWith('@')
+              ? dep.split('/').slice(0, 2).join('/')
+              : dep.split('/')[0]
+            if (!sharedList.includes(pkg)) {
+              hasExportStarFromNonShared = true
+              break
+            }
+          }
+        } catch {
+          /* can't read module */
+        }
+
+        if (hasExportStarFromNonShared) continue
+
         safeToExclude.add(name)
 
-        // Scan for CJS sub-deps that need force-inclusion
         try {
           const realPath = nodeRequire.resolve(name)
           const entryDir = realPath.substring(0, realPath.lastIndexOf('/'))
           const src = readFileSync(realPath, 'utf-8')
-          // Find relative chunk imports
+
+          // Collect non-shared bare deps from the ENTRY file
+          const entryBareDeps = [
+            ...src.matchAll(/from\s+['"]([^'"./][^'"]*)['"]/g)
+          ]
+            .map((m) => m[1])
+            .filter((d) => !d.includes('$'))
+          for (const dep of entryBareDeps) {
+            const pkg = dep.startsWith('@')
+              ? dep.split('/').slice(0, 2).join('/')
+              : dep.split('/')[0]
+            if (!sharedList.includes(pkg)) {
+              cjsSubDeps.add(pkg)
+            }
+          }
+
+          // Scan internal chunks for non-shared bare deps too
           const relImports = [...src.matchAll(/from\s+['"](\.\/.+?)['"]/g)].map(
             (m) => m[1]
           )
-          // Scan each chunk for bare-specifier imports to non-shared packages.
-          // Resolve from the module's own directory (not project root) to
-          // find nested deps like react-router/node_modules/cookie/.
           for (const rel of relImports) {
             try {
               const chunkSrc = readFileSync(join(entryDir, rel), 'utf-8')
@@ -385,12 +428,9 @@ export const get = async (module) => {
                 const pkg = dep.startsWith('@')
                   ? dep.split('/').slice(0, 2).join('/')
                   : dep.split('/')[0]
-                if (sharedList.includes(pkg)) continue
-                // Any non-shared bare import from an excluded module's
-                // internal chunk must be force-included for pre-bundling.
-                // Without this, Vite serves the raw CJS file which
-                // browsers can't parse.
-                cjsSubDeps.add(pkg)
+                if (!sharedList.includes(pkg)) {
+                  cjsSubDeps.add(pkg)
+                }
               }
             } catch {
               /* can't read chunk */
@@ -502,6 +542,8 @@ export const get = async (module) => {
             next()
             return
           }
+
+          console.log('[federation:deps-middleware] Patching:', matchedName, 'url:', url)
 
           const matchedBase = matchedName
             .split('/')

--- a/packages/lib/src/dev/expose-development.ts
+++ b/packages/lib/src/dev/expose-development.ts
@@ -60,9 +60,7 @@ const getExportNamesStatically = async (
     await lexerReady
     const code = readFileSync(resolvedPath, 'utf-8')
     const [, exports] = parse(code)
-    return exports
-      .map((e) => (typeof e === 'string' ? e : e.n))
-      .filter(Boolean)
+    return exports.map((e) => (typeof e === 'string' ? e : e.n)).filter(Boolean)
   } catch {
     return []
   }
@@ -445,7 +443,6 @@ export const get = async (module) => {
         excludedShared.add(name)
       }
 
-      
       if (safeToExclude.size > 0) {
         config.optimizeDeps ??= {}
         config.optimizeDeps.exclude = [
@@ -542,8 +539,6 @@ export const get = async (module) => {
             next()
             return
           }
-
-          console.log('[federation:deps-middleware] Patching:', matchedName, 'url:', url)
 
           const matchedBase = matchedName
             .split('/')

--- a/packages/lib/src/dev/remote-development.ts
+++ b/packages/lib/src/dev/remote-development.ts
@@ -210,10 +210,7 @@ export {__federation_method_ensure, __federation_method_getRemote , __federation
       }
     },
     async transform(this: TransformPluginContext, code: string, id: string) {
-      if (
-        (builderInfo.isHost || builderInfo.isShared) &&
-        !builderInfo.isRemote
-      ) {
+      if (builderInfo.isHost || builderInfo.isShared) {
         for (const arr of parsedOptions.devShared) {
           if (!arr[1].version && !arr[1].manuallyPackagePathSetting) {
             const packageJsonPath = (

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -106,12 +106,12 @@ const federation = (options: VitePluginFederationOptions): Plugin => {
       }
       return _options
     },
-    config(config: UserConfig, env: ConfigEnv) {
+    async config(config: UserConfig, env: ConfigEnv) {
       options.mode = options.mode ?? env.mode
       registerPlugins(options.mode, env.command)
       registerCount++
       for (const pluginHook of pluginList) {
-        pluginHook.config?.call(this, config, env)
+        await pluginHook.config?.call(this, config, env)
       }
 
       // only run when builder is vite since rollup doesn't have hook named `config`


### PR DESCRIPTION
…ter, SSO, etc.)

Three bugs were causing shared modules to create duplicate instances in dev mode, breaking React contexts (LocationContext, ReactReduxContext, SSO selectors, etc.) when MFEs are loaded by a host SPA.

## Bug 1: async config hook not awaited (index.ts)

The main plugin's config hook called sub-plugin config hooks without `await`. The devExposePlugin's config hook is async (it calls `getModuleExportNames()`), so sharedModuleMeta was never populated before configureServer ran. This meant the .vite/deps/ response middleware was never registered, and pre-bundled shared modules were served completely unpatched.

Fix: make the config hook async and await each sub-plugin's config.

## Bug 2: version resolution skipped for remotes (remote-development.ts)

The version resolution guard `(isHost || isShared) && !isRemote` prevented version resolution when the app is a remote, even if it also has shared modules. Since MFEs are always remotes (they have `exposes`) AND have shared modules, shared module versions were never resolved, resulting in `'undefined'` version strings in the shareScope.

Fix: remove the `!isRemote` guard — resolve versions whenever shared modules are configured.

## Bug 3: ESM shared modules staying pre-bundled (expose-development.ts)

When a shared ESM module stays pre-bundled in .vite/deps/, other pre-bundled deps import its internal chunks directly, bypassing the shared facade. This creates duplicate module instances — e.g. two LocationContext objects for react-router, two SSO selector stores.

The fix excludes ALL non-CJS shared modules from dep optimization so the resolveId/load virtual wrapper intercepts every import (including from other pre-bundled deps). Non-shared bare-specifier dependencies found in the entry or internal chunks are force-included via optimizeDeps.include so the browser can load them.

One exception: modules whose entry uses `export * from "cjs-pkg"` (e.g. @reduxjs/toolkit does `export * from "redux"`) cannot be excluded. `export *` requires the target module to expose static named ESM exports, but CJS modules pre-bundled by Vite only have a default export. These modules stay pre-bundled and are patched by the .vite/deps/ response middleware.

### Module strategy summary:

| Module                | Strategy      | Reason                          |
|-----------------------|---------------|---------------------------------|
| react, react-dom,     | Pre-bundled   | CJS — `t` factory patched by    |
| react-redux, zustand  |               | middleware                      |
| @reduxjs/toolkit      | Pre-bundled   | `export * from "redux"` (CJS)   |
| react-router          | Excluded      | Pure relative imports in entry  |
| @mesh-tenant-westpac- | Excluded      | ESM, no `export *` from CJS     |
| viteframework/sso     |               |                                 |

