### PR TITLE
fix: preserve directory depth in e2e temp copy for pnpm symlinks

### DIFF
--- a/packages/examples/vitestGlobalSetup.ts
+++ b/packages/examples/vitestGlobalSetup.ts
@@ -27,8 +27,11 @@ export const setup = async (): Promise<void> => {
     await new Promise((r) => setTimeout(r, 2000));
   }
 
-  const tempDir = path.resolve(__dirname, '../../temp');
-  await fs.rm(tempDir, { recursive: true, force: true });
+  const tempRoot = path.resolve(__dirname, '../../temp');
+  await fs.rm(tempRoot, { recursive: true, force: true });
+  // Preserve the same directory depth as packages/examples/ so that
+  // relative pnpm symlinks in node_modules resolve correctly.
+  const tempDir = path.join(tempRoot, 'packages', 'examples');
   await fs.mkdir(tempDir, { recursive: true });
   await fs
     .cp(path.resolve(__dirname), tempDir, {

--- a/packages/examples/vitestSetup-shared.ts
+++ b/packages/examples/vitestSetup-shared.ts
@@ -87,7 +87,7 @@ export const setupTestSuite = (config: ModeConfig): void => {
       testDir = dirname(testPath);
 
       if (testName) {
-        testDir = resolve(workspaceRoot, 'temp', testName);
+        testDir = resolve(workspaceRoot, 'temp', 'packages', 'examples', testName);
 
         await execa('pnpm', ['run', config.buildCommand], {
           cwd: testDir,


### PR DESCRIPTION
The globalSetup copies packages/examples/ to temp/ for e2e tests, but this flattened the path by 2 levels (packages/examples/ → temp/). Relative pnpm symlinks in node_modules (e.g. ../../../../../node_modules/.pnpm/) would overshoot the repo root and fail to resolve.

Fix by copying to temp/packages/examples/ instead, preserving the same directory depth so all relative symlinks resolve correctly.